### PR TITLE
Fetch CoraLibre-android-sdk from Jitpack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "CoraLibre-android-sdk"]
-	path = CoraLibre-android-sdk
-	url = https://github.com/CoraLibre/CoraLibre-android-sdk.git

--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -264,7 +264,7 @@ dependencies {
     debugImplementation 'androidx.fragment:fragment-testing:1.2.4'
 
     // CoraLibre sdk including the FOSS EN service reimplementation
-    implementation 'CoraLibre:sdk'
+    implementation 'com.github.CoraLibre:CoraLibre-android-sdk:592ec0093d08a0fb276150c45ecfe309f4a694d9'
 
     // HTTP
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-//        mavenLocal()
-
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,2 @@
 rootProject.name = 'Corona-Warn'
 include ':Corona-Warn-App', ':Server-Protocol-Buffer'
-
-includeBuild 'CoraLibre-android-sdk/coralibre-sdk'


### PR DESCRIPTION
This PR removes the CoraLibre-android-sdk submodule, and uses the library build provided by JitPack. I also had to add JitPack's maven repo as a dependency source: `maven { url 'https://jitpack.io' }`. The app builds fine and all tests pass. Since JitPack support has not yet been merged on the sdk side, for now I used my fork, which should be replaced with our repo before merging.

The version of the sdk downloaded from JitPack is currently identified by the (full) hash of the wanted commit. In my opinion this is the optimal way. With NewPipe at the beginning we used named versions (i.e. NewPipe 0.16.2 used NewPipeExtractor version `v0.16.2`), but that implied having to change the version every time before release. Also, most of the times we ended up using commit hashes anyway (e.g. when a change in the app required a new version of the extractor, but before the release). So at some point we stopped using version names alltogether, and I think this is the best way to go. 
  
Depends on and should be merged together with CoraLibre/CoraLibre-android-sdk#42
Fixes #5